### PR TITLE
🔧 chore(workflow): update checkout action to version v6.0.1

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,7 +4,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: chartboost/ruff-action@v1
         with:
           version: 0.13.1


### PR DESCRIPTION
Updated the checkout action in the Ruff workflow to use version v6.0.1 for improved stability and performance.