### PR TITLE
🔧 chore(workflow): update ruff-action to version 3.5.1

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           version: 0.13.1
           args: "check --extend-select I ./dmd ./examples"
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           version: 0.13.1
           args: "format --check ./dmd ./examples"


### PR DESCRIPTION
Updated the workflow to use the latest version of ruff-action for improved performance and compatibility with current dependencies.