### PR TITLE
➕ chore(deps): add mise configuration for Python and Poetry (#29)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+poetry = "2.2.1"
+python = "3.11"


### PR DESCRIPTION
Introduce mise.toml pinning python 3.11 and poetry 2.2.1 to standardize local tool versions, improve reproducibility, and simplify dependency management across environments.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
